### PR TITLE
[#165049326]画像サイズを取得できなかった際のエラーをキャッチするように

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-image-view",
-  "version": "2.1.4",
+  "version": "2.1.4-1",
   "description": "React Native modal image view with pinch zoom",
   "main": "src/ImageView",
   "scripts": {

--- a/src/ImageView.js
+++ b/src/ImageView.js
@@ -1,6 +1,7 @@
 // @flow
 
 import React, {Component, type Node, type ComponentType} from 'react';
+import _ from 'lodash'
 import {
     ActivityIndicator,
     Animated,
@@ -152,7 +153,9 @@ export default class ImageView extends Component<PropsType, StateType> {
         );
 
         if (imagesWithoutSize.length) {
-            Promise.all(fetchImageSize(imagesWithoutSize)).then(
+            Promise.all(_.map(fetchImageSize(imagesWithoutSize), (promise)=> {
+                return promise.catch(error => { return error })
+            })).then(
                 this.setSizeForImages
             );
         }
@@ -181,7 +184,9 @@ export default class ImageView extends Component<PropsType, StateType> {
                 );
 
                 if (imagesWithoutSize.length) {
-                    Promise.all(fetchImageSize(imagesWithoutSize)).then(
+                    Promise.all(_.map(fetchImageSize(imagesWithoutSize), (promise)=> {
+                        return promise.catch(error => { return error })
+                    })).then(
                         updatedImages =>
                             this.onNextImagesReceived(
                                 this.setSizeForImages(updatedImages),
@@ -774,7 +779,6 @@ export default class ImageView extends Component<PropsType, StateType> {
             imageScale === imageInitialScale && imageIndex > 0;
         const isNextVisible =
             imageScale === imageInitialScale && imageIndex < images.length - 1;
-
         return (
             <Modal
                 transparent

--- a/src/utils.js
+++ b/src/utils.js
@@ -115,7 +115,12 @@ export function fetchImageSize(images: Array<ImageType> = []) {
                             height,
                             index: image.index,
                         }),
-                    reject
+                    () => 
+                        reject({
+                            width: 0,
+                            height: 0,
+                            index: image.index,
+                        })
                 );
             });
 


### PR DESCRIPTION
# やったこと
* ImageView.js：Promise.allの中で、一つずつエラーをキャッチするよう修正
* utils.js：fetchImageSize内のPromiseのrejectの処理を追加
・サイズ取得のエラーが発生した際は、width、heightを０にセットするように