### PR TITLE
add initialNumToRender=100

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-image-view",
-  "version": "2.1.4-4",
+  "version": "2.1.4-5",
   "description": "React Native modal image view with pinch zoom",
   "main": "src/ImageView",
   "scripts": {

--- a/src/ImageView.js
+++ b/src/ImageView.js
@@ -829,6 +829,7 @@ export default class ImageView extends Component<PropsType, StateType> {
                     getItemLayout={this.getItemLayout}
                     onMomentumScrollBegin={this.onMomentumScrollBegin}
                     onMomentumScrollEnd={this.onMomentumScrollEnd}
+                    initialNumToRender={100}
                 />
                 {prev &&
                     isPrevVisible &&


### PR DESCRIPTION
初回のrender後に続きのrenderが行われるまでの間に1分近くのタイムラグが発生するため、初回renderで必要なサイズを全て表示させるようにしてしまう。