### PR TITLE
#175225455 iosにて画像詳細画面の×ボタン位置の変更

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-image-view",
-  "version": "2.1.4-７",
+  "version": "2.1.4-7",
   "description": "React Native modal image view with pinch zoom",
   "main": "src/ImageView",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-image-view",
-  "version": "2.1.4-6",
+  "version": "2.1.4-７",
   "description": "React Native modal image view with pinch zoom",
   "main": "src/ImageView",
   "scripts": {

--- a/src/styles.js
+++ b/src/styles.js
@@ -1,6 +1,11 @@
-import {StyleSheet} from 'react-native';
+import {StyleSheet, Platform, Dimensions} from 'react-native';
 
 const HEADER_HEIGHT = 60;
+
+//iphoneX以降のデバイス判定に使用
+const WINDOWS_WIDTH = 375;
+const WINDOWS_HEIGHT = 812;
+const { width, height } = Dimensions.get('window');
 
 export default function createStyles({screenWidth, screenHeight}) {
     return StyleSheet.create({
@@ -17,7 +22,7 @@ export default function createStyles({screenWidth, screenHeight}) {
         },
         header: {
             position: 'absolute',
-            top: 0,
+            top: Platform.OS == 'ios' && width >= WINDOWS_WIDTH && height >= WINDOWS_HEIGHT ? 70 : 0,
             left: 0,
             zIndex: 100,
             height: HEADER_HEIGHT,


### PR DESCRIPTION
### やったこと
*iOSにてimageviewを選択した際に表示される「×」ボタンがタップできない不具合を解消しました。

### 技術的変更点の概要
*react-native-image-view内のstyles.jsファイルを修正を実施
*androidとiphoneX以前、iphoneX以降で「×」ボタンの位置が変化するように修正しました。

### 動作確認
.androidとiphoneX以前の端末では「×」ボタンの位置がtop: 0になっていることを確認しました。
.iphoneX以降の端末では「×」ボタンがtop: 70になっていることを確認しました