### PR TITLE
画像2枚目以降、保存時のクラッシュ回避修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-image-view",
-  "version": "2.1.4-11",
+  "version": "2.1.4-12",
   "description": "React Native modal image view with pinch zoom",
   "main": "src/ImageView",
   "scripts": {

--- a/src/ImageView.js
+++ b/src/ImageView.js
@@ -775,7 +775,7 @@ export default class ImageView extends Component<PropsType, StateType> {
             scrollEnabled,
         } = this.state;
 
-        const imageName = this.props.images
+        const imageName = this.props.images[imageIndex] && this.props.images[imageIndex].source.name
         const {close, prev, next} = this.getControls();
         const imageInitialScale = this.getInitialScale();
         const headerTranslate = this.headerTranslateValue.getTranslateTransform();
@@ -822,7 +822,7 @@ export default class ImageView extends Component<PropsType, StateType> {
                     {!!close &&
                         React.createElement(close, {onPress: this.close})}
                     <View style={styles.view}>
-                        <Text numberOfLines={1} ellipsizeMode="tail" style={styles.text}>{imageName[this.state.imageIndex].source.name}</Text>
+                        <Text numberOfLines={1} ellipsizeMode="tail" style={styles.text}>{imageName}</Text>
                     </View>
                 </Animated.View>
                 <FlatList


### PR DESCRIPTION
画像が複数枚ある状態で2枚目以降の保存ボタン押下時にアプリクラッシュしてしまうので
これを回避するように修正しました。